### PR TITLE
Clustering update

### DIFF
--- a/backend/src/embeddingHandler.ts
+++ b/backend/src/embeddingHandler.ts
@@ -36,7 +36,7 @@ export function generateTopKSimilarEdges(nodes: { id: string, embedding: number[
     for (let j = i + 1; j < nodeCount; j++) { // Only process each pair once
       const rankAtoB = similarityRankings[i].findIndex(r => r.targetIndex === j) + 1;
       const rankBtoA = similarityRankings[j].findIndex(r => r.targetIndex === i) + 1;
-      const mutualRankScore = rankAtoB + rankBtoA;
+      const mutualRankScore = 1 / (rankAtoB + rankBtoA);
 
       // Order links lexicographically for deterministic results that are easier to filter
       const id1 = nodes[i].id;
@@ -49,8 +49,8 @@ export function generateTopKSimilarEdges(nodes: { id: string, embedding: number[
     }
   }
 
-  // Sort connections by mutual rank score (lower is better)
-  potentialEdges.sort((a, b) => a.mutualRankScore - b.mutualRankScore);
+  // Sort connections by mutual rank score (higher is better)
+  potentialEdges.sort((a, b) => b.mutualRankScore - a.mutualRankScore);
 
   // Select top n*k connections
   const topConnections = potentialEdges.slice(0, nodeCount * k);

--- a/backend/src/embeddingHandler.ts
+++ b/backend/src/embeddingHandler.ts
@@ -7,10 +7,12 @@ import config from './config';
  * Generates edges between the most semantically similar nodes using mutual rank scoring.
  *
  * For each pair of nodes, calculates their cosine similarity and relative ranking in each other's
- * similarity lists. The mutual rank score is the product of these rankings (lower is better).
+ * similarity lists. The mutual rank score is the inverse of the sum of these rankings (higher is better).
  *
  * For example, if node A ranks node B as its 2nd most similar, and B ranks A as its 3rd most
- * similar, their mutual rank score would be 2 * 3 = 6.
+ * similar, their mutual rank score would be 1 / (2 + 3) = 0.2.
+ *
+ * This score is then adjusted by the clarity score of each node, if provided.
  *
  * @param nodes - Array of nodes with embeddings to analyze
  * @param k - Number of edges per node to generate (default 2)

--- a/backend/src/embeddingHandler.ts
+++ b/backend/src/embeddingHandler.ts
@@ -55,8 +55,11 @@ export function generateTopKSimilarEdges(nodes: { id: string, embedding: number[
   // Sort connections by mutual rank score (higher is better)
   potentialEdges.sort((a, b) => b.edgePriority - a.edgePriority);
 
+  // Normalize nodeCount to account for clarity scores
+  const normalizedNodeCount = nodes.reduce((sum, node) => sum + (node.clarity ?? 1), 0);
+
   // Select top n*k connections
-  const topConnections = potentialEdges.slice(0, nodeCount * k);
+  const topConnections = potentialEdges.slice(0, normalizedNodeCount * k);
 
   return topConnections.map(link => ({
     sourceId: link.sourceId,

--- a/backend/src/embeddingHandler.ts
+++ b/backend/src/embeddingHandler.ts
@@ -5,13 +5,13 @@ import config from './config';
 
 /**
  * Generates edges between the most semantically similar nodes using mutual rank scoring.
- * 
+ *
  * For each pair of nodes, calculates their cosine similarity and relative ranking in each other's
  * similarity lists. The mutual rank score is the product of these rankings (lower is better).
- * 
+ *
  * For example, if node A ranks node B as its 2nd most similar, and B ranks A as its 3rd most
  * similar, their mutual rank score would be 2 * 3 = 6.
- * 
+ *
  * @param nodes - Array of nodes with embeddings to analyze
  * @param k - Number of edges per node to generate (default 2)
  * @returns Array of edges connecting the most similar node pairs
@@ -36,7 +36,7 @@ export function generateTopKSimilarEdges(nodes: { id: string, embedding: number[
     for (let j = i + 1; j < nodeCount; j++) { // Only process each pair once
       const rankAtoB = similarityRankings[i].findIndex(r => r.targetIndex === j) + 1;
       const rankBtoA = similarityRankings[j].findIndex(r => r.targetIndex === i) + 1;
-      const mutualRankScore = rankAtoB * rankBtoA;
+      const mutualRankScore = rankAtoB + rankBtoA;
 
       // Order links lexicographically for deterministic results that are easier to filter
       const id1 = nodes[i].id;

--- a/backend/src/embeddingHandler.ts
+++ b/backend/src/embeddingHandler.ts
@@ -18,7 +18,7 @@ import config from './config';
  * @param k - Number of edges per node to generate (default 2)
  * @returns Array of edges connecting the most similar node pairs
  */
-export function generateTopKSimilarEdges(nodes: { id: string, embedding: number[], clarity?: number }[], k = 2): { sourceId: string, targetId: string }[] {
+export function generateTopKSimilarEdges(nodes: { id: string, embedding: number[], clarity: number }[], k = 2): { sourceId: string, targetId: string }[] {
   const nodeCount = nodes.length;
   const potentialEdges: { sourceId: string, targetId: string, edgePriority: number }[] = [];
 
@@ -58,7 +58,7 @@ export function generateTopKSimilarEdges(nodes: { id: string, embedding: number[
   potentialEdges.sort((a, b) => b.edgePriority - a.edgePriority);
 
   // Normalize nodeCount to account for clarity scores
-  const normalizedNodeCount = nodes.reduce((sum, node) => sum + (node.clarity ?? 1), 0);
+  const normalizedNodeCount = nodes.reduce((sum, node) => sum + node.clarity, 0);
 
   // Select top n*k connections
   const topConnections = potentialEdges.slice(0, normalizedNodeCount * k);


### PR DESCRIPTION
@sofvanh  

I've updated generateTopKSimilarEdges to cluster nodes taking their clarity into account (low clarity nodes get less connections). 

What still needs to be done is clarity scores for each node need to be passed to generateTopKSimilarEdges. Can I leave that to you? I didn't want to mess with contents of "node" in graphArgs without you. 

Currently, if there is no clarity, it defaults to a clarity score of 1. 