### PR TITLE
Fixing "not enough data" bug

### DIFF
--- a/backend/src/analysis/argumentScoreHandler.ts
+++ b/backend/src/analysis/argumentScoreHandler.ts
@@ -62,15 +62,18 @@ function getFragmentationScore(argumentIndex: number,
     row[argumentIndex] !== 0 ? i : null).filter(i => i !== null) as number[];
 
   // Users are automatically in their own ingroup, so no need to filter
-  const usersWithIngroup = usersWhoVoted;
+
+  if (usersWhoVoted.length === 0) {
+    return null;
+  }
 
   // Compute individual user scores (to be aggregated as the final argument score later)
-  const userFragmentationScores = new Array(usersWithIngroup.length).fill(0);
+  const userFragmentationScores = new Array(usersWhoVoted.length).fill(0);
 
-  for (let i = 0; i < usersWithIngroup.length; i++) {
-    const vote = votingMatrix[usersWithIngroup[i]][argumentIndex];
-    const sumIngroupAgree = sum_pos_pos[usersWithIngroup[i]][argumentIndex];
-    const sumIngroupDisagree = sum_pos_neg[usersWithIngroup[i]][argumentIndex];
+  for (let i = 0; i < usersWhoVoted.length; i++) {
+    const vote = votingMatrix[usersWhoVoted[i]][argumentIndex];
+    const sumIngroupAgree = sum_pos_pos[usersWhoVoted[i]][argumentIndex];
+    const sumIngroupDisagree = sum_pos_neg[usersWhoVoted[i]][argumentIndex];
     const sumDisalignedIngroup = vote === -1 ? sumIngroupAgree : sumIngroupDisagree;
 
     userFragmentationScores[i] = sumDisalignedIngroup / (sumIngroupAgree + sumIngroupDisagree);
@@ -79,8 +82,8 @@ function getFragmentationScore(argumentIndex: number,
   // Average of user scores, weighted by uniqueness
   let fragmentationSum = 0;
   let uniquenessSum = 0;
-  for (let i = 0; i < usersWithIngroup.length; i++) {
-    let uniqueness = uniquenessMatrix[usersWithIngroup[i]][argumentIndex];
+  for (let i = 0; i < usersWhoVoted.length; i++) {
+    let uniqueness = uniquenessMatrix[usersWhoVoted[i]][argumentIndex];
 
     fragmentationSum += userFragmentationScores[i] * uniqueness;
     uniquenessSum += uniqueness;

--- a/backend/src/analysis/argumentScoreHandler.ts
+++ b/backend/src/analysis/argumentScoreHandler.ts
@@ -61,14 +61,8 @@ function getFragmentationScore(argumentIndex: number,
   const usersWhoVoted = votingMatrix.map((row, i) =>
     row[argumentIndex] !== 0 ? i : null).filter(i => i !== null) as number[];
 
-  // Filter for users with an ingroup
-  const usersWithIngroup = usersWhoVoted.filter(i =>
-    sum_pos_pos[i][argumentIndex] + sum_pos_neg[i][argumentIndex] > 0);
-
-  // If no users have an ingroup, can't calculate fragmentation
-  if (usersWithIngroup.length === 0) {
-    return null;
-  }
+  // Users are automatically in their own ingroup, so no need to filter
+  const usersWithIngroup = usersWhoVoted;
 
   // Compute individual user scores (to be aggregated as the final argument score later)
   const userFragmentationScores = new Array(usersWithIngroup.length).fill(0);
@@ -103,7 +97,7 @@ function getClarityScore(argumentIndex: number,
    * One minus average number of unclear votes
    */
 
-  //Identify all users who reacted on this argument 
+  //Identify all users who reacted on this argument
   const usersWhoReacted = votingMatrix.map((row, i) =>
     (row[argumentIndex] !== 0 || unclearMatrix[i][argumentIndex] !== 0) ? i : null
   ).filter(i => i !== null) as number[];

--- a/backend/src/analysis/argumentScoreHandler.ts
+++ b/backend/src/analysis/argumentScoreHandler.ts
@@ -144,9 +144,10 @@ export async function getArgumentScores(graphId: string): Promise<Map<string, Sc
     const fragmentation = getFragmentationScore(argumentIndex, votingMatrix, sum_pos_pos, sum_pos_neg, uniquenessMatrix);
     const clarity = getClarityScore(argumentIndex, votingMatrix, unclearMatrix, uniquenessMatrix);
 
+
     argumentScores.set(argumentId, {
       consensus: consensus === null ? undefined : consensus,
-      fragmentation: fragmentation == null ? undefined : fragmentation,
+      fragmentation: fragmentation === null ? undefined : fragmentation,
       clarity
     });
   });

--- a/backend/src/analysis/argumentScoreHandler.ts
+++ b/backend/src/analysis/argumentScoreHandler.ts
@@ -143,7 +143,7 @@ export async function getArgumentScores(graphId: string): Promise<Map<string, Sc
 
     argumentScores.set(argumentId, {
       consensus: consensus === null ? undefined : consensus,
-      fragmentation: fragmentation,
+      fragmentation: fragmentation == null ? undefined : fragmentation,
       clarity
     });
   });

--- a/backend/src/analysis/argumentScoreHandler.ts
+++ b/backend/src/analysis/argumentScoreHandler.ts
@@ -86,7 +86,13 @@ function getFragmentationScore(argumentIndex: number,
     uniquenessSum += uniqueness;
   }
 
-  return 2 * fragmentationSum / uniquenessSum;
+  const fragmentationScore = 2 * fragmentationSum / uniquenessSum;
+
+  if (!isFinite(fragmentationScore)) {
+    throw new Error("Fragmentation score is not a finite number");
+  }
+
+  return fragmentationScore;
 }
 
 function getClarityScore(argumentIndex: number,
@@ -135,10 +141,9 @@ export async function getArgumentScores(graphId: string): Promise<Map<string, Sc
     const fragmentation = getFragmentationScore(argumentIndex, votingMatrix, sum_pos_pos, sum_pos_neg, uniquenessMatrix);
     const clarity = getClarityScore(argumentIndex, votingMatrix, unclearMatrix, uniquenessMatrix);
 
-
     argumentScores.set(argumentId, {
       consensus: consensus === null ? undefined : consensus,
-      fragmentation: fragmentation === null ? undefined : fragmentation,
+      fragmentation: fragmentation,
       clarity
     });
   });

--- a/frontend/src/components/ArgumentInfoBox/ArgumentInfoMedium.tsx
+++ b/frontend/src/components/ArgumentInfoBox/ArgumentInfoMedium.tsx
@@ -96,8 +96,12 @@ const ArgumentInfoMedium: React.FC<ArgumentInfoMediumProps> = ({
         <div className="flex flex-col gap-1 mt-1">
           {argument.score ? (
             <>
-              <span className="text-xs text-stone-500">Consensus: {argument.score.consensus ? Math.round(argument.score.consensus * 100) + "%" : "More data needed"}</span>
-              <span className="text-xs text-stone-500">Fragmentation: {argument.score.fragmentation ? Math.round(argument.score.fragmentation * 100) + "%" : "More data needed"}</span>
+              <span className="text-xs text-stone-500">
+                Consensus: {argument.score.consensus !== null && argument.score.consensus !== undefined ? Math.round(argument.score.consensus * 100) + "%" : "More data needed"}
+              </span>
+              <span className="text-xs text-stone-500">
+                Fragmentation: {argument.score.fragmentation !== null && argument.score.fragmentation !== undefined ? Math.round(argument.score.fragmentation * 100) + "%" : "Error in calculation"}
+              </span>
               <span className="text-xs text-stone-500">Clarity: {Math.round(argument.score.clarity * 100)}%</span>
             </>
           ) : (

--- a/frontend/src/components/ArgumentInfoBox/ArgumentInfoMedium.tsx
+++ b/frontend/src/components/ArgumentInfoBox/ArgumentInfoMedium.tsx
@@ -100,7 +100,7 @@ const ArgumentInfoMedium: React.FC<ArgumentInfoMediumProps> = ({
                 Consensus: {argument.score.consensus !== null && argument.score.consensus !== undefined ? Math.round(argument.score.consensus * 100) + "%" : "More data needed"}
               </span>
               <span className="text-xs text-stone-500">
-                Fragmentation: {argument.score.fragmentation !== null && argument.score.fragmentation !== undefined ? Math.round(argument.score.fragmentation * 100) + "%" : "Error in calculation"}
+                Fragmentation: {argument.score.fragmentation !== null && argument.score.fragmentation !== undefined ? Math.round(argument.score.fragmentation * 100) + "%" : "More data needed"}
               </span>
               <span className="text-xs text-stone-500">Clarity: {Math.round(argument.score.clarity * 100)}%</span>
             </>


### PR DESCRIPTION
This branch is badly named. I thought maybe there was a bug in the score calculation, but I didn't find it.

1. I removed redundant code in fragmentation score calculation (if there is a single vote, there is ALWAYS enough data to compute fragmentation, because users are defined to be members of their own ingroups)
2. Added an error message (just in case something funky happens with fragmentation score)
3. Fixed a frontend bug in score rendering, where scores of zero are rendered as "not enough data"

Everything should be fixed now! Just need you @sofvanh to double check it's above board.