### PR TITLE
Update to argument priority

### DIFF
--- a/backend/src/analysis/argumentPriorityHandler.ts
+++ b/backend/src/analysis/argumentPriorityHandler.ts
@@ -47,7 +47,7 @@ export async function getArgumentPriorities(graphId: string, userId: string): Pr
   // Get priority for arguments with scores (consensus, fragmentation, clarity)
   for (const [argumentId, score] of argumentScores) {
     const uniquenessScore = uniquenessScores.get(argumentId) ?? 1;
-    const priority = (1 + 50 * (score.consensus ?? 0) + 50 * (score.fragmentation ?? 0)) * (score.clarity ** 2) * (uniquenessScore ** 2);
+    const priority = (1 + 20 * (score.consensus ?? 0) + 20 * (score.fragmentation ?? 0)) * (score.clarity + uniquenessScore) ** 2;
     argumentPriorityMap.set(argumentId, priority);
   }
 


### PR DESCRIPTION
Currently, if clarity is zero, then a statement will never appear in the feed. If the first reaction anyone gives is low-quality, then that permanently prevents new reactions (unless someone finds it in the graph). 

This update ensures that even zero clarity nodes will still get included in the feed. 