### PR TITLE
lower alpha decay to let graph settle better

### DIFF
--- a/frontend/src/components/GraphVisualization.tsx
+++ b/frontend/src/components/GraphVisualization.tsx
@@ -58,6 +58,7 @@ const GraphVisualization: React.FC<GraphVisualizationProps> = ({
       nodeCanvasObjectMode={() => 'replace'}
       nodeRelSize={15}
       autoPauseRedraw={true}
+      d3AlphaDecay={0.01}
     />
   );
 };


### PR DESCRIPTION
To help prevent the graph from settling too quickly (and there being weird overlaps), I've lowered the alpha decay. This gives the graph a little bit more time and flexibility to settle into a more sensible shape.