### PR TITLE
increase threshold from 3 votes to 7 votes

### DIFF
--- a/backend/src/db/operations/reactionOperations.ts
+++ b/backend/src/db/operations/reactionOperations.ts
@@ -53,7 +53,7 @@ export async function getReactionsForAnalysis(
           WHERE a.graph_id = $1
             AND r.type IN ('agree', 'disagree')
           GROUP BY user_id
-          HAVING COUNT(*) >= 3
+          HAVING COUNT(*) >= 7
         ),
         reaction_matrices AS (
           SELECT


### PR DESCRIPTION
to avoid spurious effects from users who only voted a couple times. seven votes gives the system a bit more information to compute similarity scores. 

I have tested this, and it works fine.